### PR TITLE
Updated instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Build PleromaPi
 
 PleromaPi can be built using docker running either on an intel or RaspberryPi (supported ones listed).
 Build requires about 4.5 GB of free space available.
-You can build it assuming you already have docker and docker-compose installed issuing the following commands::
+You can build it assuming you already have docker installed issuing the following commands::
 
     
     git clone https://github.com/guysoft/PleromaPi.git

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Requirements
 ~~~~~~~~~~~~
 
 #. Docker or Vagrant, docker recommended
-#. Downloaded `Ubuntu for RaspeberryPi image <https://ubuntu.com/download/raspberry-pi/>`_ image. Official releases use the LTS version.
+#. Downloaded `Ubuntu for RaspberryPi image <https://ubuntu.com/download/raspberry-pi/>`_ image. Official releases use the LTS version.
 #. Root privileges for chroot
 #. Bash
 #. sudo (the script itself calls it, running as root without sudo won't work)

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ PleromaPi
 =========
 
 An out of the box `Raspberry Pi <http://www.raspberrypi.org/>`_ Raspbian distro that runs `Pleroma <https://pleroma.social/>`_ using Docker and Nginx-proxy as a reverse proxy, with letsencrypt.
-It uses the `docker-compose yaml for pleroma here <https://git.pleroma.social/guysoft/pleroma-docker-compose/-/blob/devel/docker-compose.yml>`_.
+It uses the `docker compose yaml for pleroma here <https://git.pleroma.social/guysoft/pleroma-docker-compose/-/blob/devel/docker-compose.yml>`_.
 
 
 Where to get it?

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,6 @@ Requirements
 ~~~~~~~~~~~~
 
 #. Docker or Vagrant, docker recommended
-#. Docker-compose - recommended if using docker build method, instructions assume you have it
 #. Downloaded `Ubuntu for RaspeberryPi image <https://ubuntu.com/download/raspberry-pi/>`_ image. Official releases use the LTS version.
 #. Root privileges for chroot
 #. Bash
@@ -73,7 +72,7 @@ You can build it assuming you already have docker and docker-compose installed i
     cd PleromaPi/src/image
     wget -c --trust-server-names 'https://cdimage.ubuntu.com/releases/20.04.2/release/ubuntu-20.04.4-preinstalled-server-arm64+raspi.img.xz'
     cd ..
-    sudo docker-compose up -d
+    sudo docker compose up -d
     sudo docker exec -it pleromapi-build build
     
 Building PleromaPi Variants


### PR DESCRIPTION
The instructions mentioned to use docker-compose. However, when I did this, i got this error: "urllib3.exceptions.URLSchemeUnknown: Not supported URL scheme http+docker" 

I found [here](https://forums.docker.com/t/error-while-fetching-server-api-version-not-supported-url-scheme-http-docker/141942) that **docker compose** should be used and not the older version **docker-compose**. 

So basically, just a small change to the instructions.